### PR TITLE
Use @_cdecl in Swift

### DIFF
--- a/NativeExtensionInSwift/Sources/NativeExtensionInSwift/NativeExtensionInSwift.swift
+++ b/NativeExtensionInSwift/Sources/NativeExtensionInSwift/NativeExtensionInSwift.swift
@@ -1,15 +1,14 @@
-public struct NativeExtensionInSwift {
-    
-    public func fibonacci(_ n: CInt) -> CInt {
-        if n == 0 {
-            return 0
-        } else if n == 1{
-            return 1
-        }
-        return fibonacci(n - 1) + fibonacci(n - 2)
+@_cdecl("swift_fibonacci")
+public func fibonacci(_ n: CInt) -> CInt {
+    if n == 0 {
+        return 0
+    } else if n == 1{
+        return 1
     }
-    
-    public func printHello() {
-        print("hello")
-    }
+    return fibonacci(n - 1) + fibonacci(n - 2)
+}
+
+@_cdecl("swift_print_hello")
+public func printHello() {
+    print("hello")
 }

--- a/swift.cc
+++ b/swift.cc
@@ -24,10 +24,8 @@ const string SHARED_LIBRARY_EXT = "so";
 
 const string SWIFT_SHARED_LIBRARY_PATH = "./NativeExtensionInSwift/.build/debug/libNativeExtensionInSwift."+SHARED_LIBRARY_EXT;
 
-// Symbol name will be changed.
-// Got by nm -gU ./NativeExtensionInSwift/.build/debug/libNativeExtensionInSwift.dylib
-const auto SWIFT_FIBONACCI_FUNC_SYMBOL = "_T022NativeExtensionInSwiftAAV9fibonaccis5Int32VAEF";
-const auto SWIFT_PRINT_HELLO_FUNC_SYMBOL = "_T022NativeExtensionInSwiftAAV10printHelloyyF";
+const auto SWIFT_FIBONACCI_FUNC_SYMBOL = "swift_fibonacci";
+const auto SWIFT_PRINT_HELLO_FUNC_SYMBOL = "swift_print_hello";
 
 typedef int (*FibonacciFunc)(int);
 typedef void (*PrintHelloFunc)();


### PR DESCRIPTION
This way, the mangled names do not need to be regenerated when the signature changes.

This also helps when upgrading to Swift 4.x, which modifies the mangling structure.